### PR TITLE
Fix breaking package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "handlebars": "^2.0.0",
     "hubot-auth": "^1.2.0",
     "redis": "^0.12.1",
-    "time": "0.11.0",
+    "time": "0.11.4",
     "request": ""
   },
   "main": "index.coffee"


### PR DESCRIPTION
This package fails to build

time@0.11.0 install: `node-gyp rebuild`
